### PR TITLE
updates for deletion and book-keeping

### DIFF
--- a/core/store/src/main/java/org/locationtech/geowave/core/store/adapter/AdapterIndexMappingStore.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/adapter/AdapterIndexMappingStore.java
@@ -33,13 +33,24 @@ public interface AdapterIndexMappingStore
 			AdapterToIndexMapping mapping );
 
 	/**
-	 * Adapter to index mappings are maintain without regard to visibility
+	 * Adapter to index mappings are maintained without regard to visibility
 	 * constraints.
 	 *
 	 * @param adapterId
 	 */
 	public void remove(
 			short adapterId );
+	
+	/**
+	 * Remove an index for the specified adapter mapping.
+	 * The method should return false if the adapter, or index for the 
+	 * adapter does not exist.
+	 *
+	 * @param adapterId
+	 * @param indexName
+	 */
+	public boolean remove(
+			short adapterId, String indexName );
 
 	public void removeAll();
 }

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/api/DataStore.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/api/DataStore.java
@@ -132,9 +132,11 @@ public interface DataStore
 			Index... indices );
 
 	/**
-	 * remove statistics, across types
-	 * 
-	 * if this is the last index for a type we need to throw an exception
+	 * This method removes an index from the index store. It is also
+	 * responsible for removing the index's mapping, data, and stats 
+	 * for each adapter/type that was associated with the index. If this
+	 * is the last index associated with any of the existing adapters,
+	 * the method will throw an exception.
 	 * 
 	 * @param indexName
 	 */
@@ -142,13 +144,23 @@ public interface DataStore
 			String indexName )
 			throws AdapterException;
 
+	/**
+	 * This method removes an index mapping with a given adapter/type. It is 
+	 * also data, and stats for the adapter that was associated with the index.
+	 * If this is the last index associated with type the method will throw 
+	 * an exception.
+	 * 
+	 * @param typeName
+	 * @param indexName
+	 */
 	void removeIndexMapping(
 			String typeName,
 			String indexName )
 			throws AdapterException, IllegalArgumentException;
 
 	/**
-	 * remove statistics for type
+	 * Removes the adapter/type, all of the data and stats, and any 
+	 * associated index mappings.
 	 * 
 	 * @param typeName
 	 */

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/api/DataStore.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/api/DataStore.java
@@ -153,7 +153,7 @@ public interface DataStore
 	 * @param typeName
 	 * @param indexName
 	 */
-	void removeIndexMapping(
+	void removeIndex(
 			String typeName,
 			String indexName )
 			throws AdapterException, IllegalArgumentException;

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/api/DataStore.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/api/DataStore.java
@@ -26,7 +26,7 @@ import org.locationtech.geowave.core.store.adapter.exceptions.MismatchedIndexToA
  */
 public interface DataStore
 {
-	 <T> void ingest(
+	<T> void ingest(
 			URL url,
 			Index... index )
 			throws MismatchedIndexToAdapterMapping;
@@ -135,22 +135,27 @@ public interface DataStore
 	 * remove statistics, across types
 	 * 
 	 * if this is the last index for a type we need to throw an exception
+	 * 
 	 * @param indexName
 	 */
 	void removeIndex(
-			String indexName ) throws AdapterException;
+			String indexName )
+			throws AdapterException;
 
-	void removeIndex(
+	void removeIndexMapping(
 			String typeName,
-			String indexName ) throws AdapterException;
+			String indexName )
+			throws AdapterException, IllegalArgumentException;
 
 	/**
 	 * remove statistics for type
+	 * 
 	 * @param typeName
 	 */
 	void removeType(
 			String typeName );
-	/**
+
+/**
 	 * Delete all data in this data store that matches the query parameter
 	 * within the index described by the index passed in and matches the adapter
 	 * (the same adapter ID as the ID ingested). All data that matches the
@@ -171,7 +176,7 @@ public interface DataStore
 	 */
 	<T> boolean delete(
 			final Query<T> query );
-	
+
 	void deleteAll();
 
 	<T> void addType(

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/api/DataStore.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/api/DataStore.java
@@ -15,6 +15,7 @@ import java.net.URL;
 import org.locationtech.geowave.core.index.Mergeable;
 import org.locationtech.geowave.core.index.persist.Persistable;
 import org.locationtech.geowave.core.store.CloseableIterator;
+import org.locationtech.geowave.core.store.adapter.exceptions.AdapterException;
 import org.locationtech.geowave.core.store.adapter.exceptions.MismatchedIndexToAdapterMapping;
 
 /**
@@ -133,15 +134,15 @@ public interface DataStore
 	/**
 	 * remove statistics, across types
 	 * 
-	 * if this is the last index for a type need to remove type first or throw exception
+	 * if this is the last index for a type we need to throw an exception
 	 * @param indexName
 	 */
 	void removeIndex(
-			String indexName );
+			String indexName ) throws AdapterException;
 
 	void removeIndex(
 			String typeName,
-			String indexName );
+			String indexName ) throws AdapterException;
 
 	/**
 	 * remove statistics for type

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/base/BaseDataStore.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/base/BaseDataStore.java
@@ -83,9 +83,7 @@ import com.google.common.collect.Streams;
 public class BaseDataStore implements
 		DataStore
 {
-	private final static Logger LOGGER = LoggerFactory
-			.getLogger(
-					BaseDataStore.class);
+	private final static Logger LOGGER = LoggerFactory.getLogger(BaseDataStore.class);
 
 	protected final IndexStore indexStore;
 	protected final PersistentAdapterStore adapterStore;
@@ -118,23 +116,15 @@ public class BaseDataStore implements
 
 	public void store(
 			final Index index ) {
-		if (baseOptions.isPersistIndex() && !indexStore
-				.indexExists(
-						index.getName())) {
-			indexStore
-					.addIndex(
-							index);
+		if (baseOptions.isPersistIndex() && !indexStore.indexExists(index.getName())) {
+			indexStore.addIndex(index);
 		}
 	}
 
 	protected synchronized void store(
 			final InternalDataAdapter<?> adapter ) {
-		if (baseOptions.isPersistAdapter() && !adapterStore
-				.adapterExists(
-						adapter.getAdapterId())) {
-			adapterStore
-					.addAdapter(
-							adapter);
+		if (baseOptions.isPersistAdapter() && !adapterStore.adapterExists(adapter.getAdapterId())) {
+			adapterStore.addAdapter(adapter);
 		}
 
 	}
@@ -156,18 +146,13 @@ public class BaseDataStore implements
 					secondaryIndexDataStore,
 					i == 0);
 
-			callbackManager
-					.setPersistStats(
-							baseOptions.isPersistDataStatistics());
+			callbackManager.setPersistStats(baseOptions.isPersistDataStatistics());
 
 			final List<IngestCallback<T>> callbacks = new ArrayList<>();
 
-			callbacks
-					.add(
-							callbackManager
-									.getIngestCallback(
-											adapter,
-											index));
+			callbacks.add(callbackManager.getIngestCallback(
+					adapter,
+					index));
 
 			final IngestCallbackList<T> callbacksList = new IngestCallbackList<>(
 					callbacks);
@@ -221,9 +206,9 @@ public class BaseDataStore implements
 	/*
 	 * Since this general-purpose method crosses multiple adapters, the type of
 	 * result cannot be assumed.
-	 *
+	 * 
 	 * (non-Javadoc)
-	 *
+	 * 
 	 * @see
 	 * org.locationtech.geowave.core.store.DataStore#query(org.locationtech.
 	 * geowave. core.store.query.QueryOptions,
@@ -262,20 +247,12 @@ public class BaseDataStore implements
 			final String constraintTypeName = ((TypeConstraintQuery) constraints).getTypeName();
 
 			if ((queryOptions.getAdapterIds() == null) || (queryOptions.getAdapterIds().length == 0)) {
-				queryOptions
-						.setAdapterId(
-								internalAdapterStore
-										.getAdapterId(
-												constraintTypeName));
+				queryOptions.setAdapterId(internalAdapterStore.getAdapterId(constraintTypeName));
 			}
 			else if (queryOptions.getAdapterIds().length == 1) {
-				final Short adapterId = internalAdapterStore
-						.getAdapterId(
-								constraintTypeName);
+				final Short adapterId = internalAdapterStore.getAdapterId(constraintTypeName);
 				if ((adapterId == null) || (queryOptions.getAdapterIds()[0] != adapterId.shortValue())) {
-					LOGGER
-							.error(
-									"Constraint Query Type name does not match Query Options Type Name");
+					LOGGER.error("Constraint Query Type name does not match Query Options Type Name");
 					throw new RuntimeException(
 							"Constraint Query Type name does not match Query Options Type Name");
 				}
@@ -283,9 +260,7 @@ public class BaseDataStore implements
 			else {
 				// Throw exception when QueryOptions has more than one adapter
 				// and CQL Adapter is set.
-				LOGGER
-						.error(
-								"Constraint Query Type name does not match Query Options Type Name");
+				LOGGER.error("Constraint Query Type name does not match Query Options Type Name");
 				throw new RuntimeException(
 						"Constraint Query Type name does not match Query Options Type Name");
 			}
@@ -302,23 +277,18 @@ public class BaseDataStore implements
 
 		try {
 			tempAdapterStore = new MemoryPersistentAdapterStore(
-					queryOptions
-							.getAdaptersArray(
-									adapterStore));
+					queryOptions.getAdaptersArray(adapterStore));
 			// keep a list of adapters that have been queried, to only load an
 			// adapter to be queried once
 			final Set<Short> queriedAdapters = new HashSet<>();
-			final List<Pair<Index, List<InternalDataAdapter<?>>>> indexAdapterPairList = delete
-					? queryOptions
-							.getIndicesForAdapters(
-									tempAdapterStore,
-									indexMappingStore,
-									indexStore)
-					: queryOptions
-							.getAdaptersWithMinimalSetOfIndices(
-									tempAdapterStore,
-									indexMappingStore,
-									indexStore);
+			final List<Pair<Index, List<InternalDataAdapter<?>>>> indexAdapterPairList = delete ? queryOptions
+					.getIndicesForAdapters(
+							tempAdapterStore,
+							indexMappingStore,
+							indexStore) : queryOptions.getAdaptersWithMinimalSetOfIndices(
+					tempAdapterStore,
+					indexMappingStore,
+					indexStore);
 			final Pair<InternalDataAdapter<?>, Aggregation<?, ?, ?>> aggregation = queryOptions.getAggregation();
 			for (final Pair<Index, List<InternalDataAdapter<?>>> indexAdapterPair : indexAdapterPairList) {
 				final List<Short> adapterIdsToQuery = new ArrayList<>();
@@ -330,41 +300,30 @@ public class BaseDataStore implements
 						final DataStoreCallbackManager callbackCache = new DataStoreCallbackManager(
 								statisticsStore,
 								secondaryIndexDataStore,
-								queriedAdapters
-										.add(
-												adapter.getAdapterId()));
-						callbackCache
-								.setPersistStats(
-										baseOptions.isPersistDataStatistics());
-						deleteCallbacks
-								.add(
-										callbackCache);
+								queriedAdapters.add(adapter.getAdapterId()));
+						callbackCache.setPersistStats(baseOptions.isPersistDataStatistics());
+						deleteCallbacks.add(callbackCache);
 						final ScanCallback callback = queryOptions.getScanCallback();
 
 						final Index index = indexAdapterPair.getLeft();
-						queryOptions
-								.setScanCallback(
-										new ScanCallback<Object, GeoWaveRow>() {
+						queryOptions.setScanCallback(new ScanCallback<Object, GeoWaveRow>() {
 
-											@Override
-											public void entryScanned(
-													final Object entry,
-													final GeoWaveRow row ) {
-												if (callback != null) {
-													callback
-															.entryScanned(
-																	entry,
-																	row);
-												}
-												callbackCache
-														.getDeleteCallback(
-																adapter,
-																index)
-														.entryDeleted(
-																entry,
-																row);
-											}
-										});
+							@Override
+							public void entryScanned(
+									final Object entry,
+									final GeoWaveRow row ) {
+								if (callback != null) {
+									callback.entryScanned(
+											entry,
+											row);
+								}
+								callbackCache.getDeleteCallback(
+										adapter,
+										index).entryDeleted(
+										entry,
+										row);
+							}
+						});
 					}
 					QueryConstraints adapterIndexConstraints;
 					if (isConstraintsAdapterIndexSpecific) {
@@ -377,91 +336,74 @@ public class BaseDataStore implements
 						adapterIndexConstraints = sanitizedConstraints;
 					}
 					if (isAggregationAdapterIndexSpecific) {
-						queryOptions
-								.setAggregation(
-										((AdapterAndIndexBasedAggregation) aggregation.getRight())
-												.createAggregation(
-														adapter,
-														indexAdapterPair.getLeft()),
-										aggregation.getLeft());
+						queryOptions.setAggregation(
+								((AdapterAndIndexBasedAggregation) aggregation.getRight()).createAggregation(
+										adapter,
+										indexAdapterPair.getLeft()),
+								aggregation.getLeft());
 					}
 					if (adapterIndexConstraints instanceof InsertionIdQuery) {
-						queryOptions
-								.setLimit(
-										-1);
-						results
-								.add(
-										queryInsertionId(
-												adapter,
-												indexAdapterPair.getLeft(),
-												(InsertionIdQuery) adapterIndexConstraints,
-												filter,
-												queryOptions,
-												tempAdapterStore,
-												delete));
+						queryOptions.setLimit(-1);
+						results.add(queryInsertionId(
+								adapter,
+								indexAdapterPair.getLeft(),
+								(InsertionIdQuery) adapterIndexConstraints,
+								filter,
+								queryOptions,
+								tempAdapterStore,
+								delete));
 						continue;
 					}
 					else if (adapterIndexConstraints instanceof PrefixIdQuery) {
 						if (!queriedAllAdaptersByPrefix) {
 							final PrefixIdQuery prefixIdQuery = (PrefixIdQuery) adapterIndexConstraints;
-							results
-									.add(
-											queryRowPrefix(
-													indexAdapterPair.getLeft(),
-													prefixIdQuery.getPartitionKey(),
-													prefixIdQuery.getSortKeyPrefix(),
-													queryOptions,
-													indexAdapterPair.getRight(),
-													tempAdapterStore,
-													delete));
+							results.add(queryRowPrefix(
+									indexAdapterPair.getLeft(),
+									prefixIdQuery.getPartitionKey(),
+									prefixIdQuery.getSortKeyPrefix(),
+									queryOptions,
+									indexAdapterPair.getRight(),
+									tempAdapterStore,
+									delete));
 							queriedAllAdaptersByPrefix = true;
 						}
 						continue;
 					}
 					else if (isConstraintsAdapterIndexSpecific || isAggregationAdapterIndexSpecific) {
 						// can't query multiple adapters in the same scan
-						results
-								.add(
-										queryConstraints(
-												Collections
-														.singletonList(
-																adapter.getAdapterId()),
-												indexAdapterPair.getLeft(),
-												sanitizedConstraints,
-												filter,
-												queryOptions,
-												tempAdapterStore,
-												delete));
+						results.add(queryConstraints(
+								Collections.singletonList(adapter.getAdapterId()),
+								indexAdapterPair.getLeft(),
+								sanitizedConstraints,
+								filter,
+								queryOptions,
+								tempAdapterStore,
+								delete));
 						continue;
 					}
 					// finally just add it to a list to query multiple adapters
 					// in on scan
-					adapterIdsToQuery
-							.add(
-									adapter.getAdapterId());
+					adapterIdsToQuery.add(adapter.getAdapterId());
 				}
 				// supports querying multiple adapters in a single index
 				// in one query instance (one scanner) for efficiency
 				if (adapterIdsToQuery.size() > 0) {
-					results
-							.add(
-									queryConstraints(
-											adapterIdsToQuery,
-											indexAdapterPair.getLeft(),
-											sanitizedConstraints,
-											filter,
-											queryOptions,
-											tempAdapterStore,
-											delete));
+					results.add(queryConstraints(
+							adapterIdsToQuery,
+							indexAdapterPair.getLeft(),
+							sanitizedConstraints,
+							filter,
+							queryOptions,
+							tempAdapterStore,
+							delete));
 				}
 			}
 
 		}
 		catch (final IOException e1) {
-			LOGGER
-					.error(
-							"Failed to resolve adapter or index for query",
-							e1);
+			LOGGER.error(
+					"Failed to resolve adapter or index for query",
+					e1);
 		}
 		return new CloseableIteratorWrapper<>(
 				new Closeable() {
@@ -478,18 +420,15 @@ public class BaseDataStore implements
 					}
 
 				},
-				Iterators
-						.concat(
-								new CastIterator<T>(
-										results.iterator())));
+				Iterators.concat(new CastIterator<T>(
+						results.iterator())));
 	}
 
 	private boolean isAllAdapters(
 			final String[] typeNames ) {
-		return Arrays
-				.equals(
-						internalAdapterStore.getTypeNames(),
-						typeNames);
+		return Arrays.equals(
+				internalAdapterStore.getTypeNames(),
+				typeNames);
 	}
 
 	public <T> boolean delete(
@@ -500,16 +439,22 @@ public class BaseDataStore implements
 		}
 		if (((query.getQueryConstraints() == null) || (query.getQueryConstraints() instanceof EverythingQuery))) {
 			if ((query.getDataTypeQueryOptions().getTypeNames() == null)
-					|| (query.getDataTypeQueryOptions().getTypeNames().length == 0) || isAllAdapters(
-							query.getDataTypeQueryOptions().getTypeNames())) {
+					|| (query.getDataTypeQueryOptions().getTypeNames().length == 0)
+					|| isAllAdapters(query.getDataTypeQueryOptions().getTypeNames())) {
 				// TODO what about authorizations here?
-				// for now just delete all of the data itself and leave stats, indices, adapters, etc. alone
+				// for now just delete all of the data itself and leave stats,
+				// indices, adapters, etc. alone
 				try {
 					// delete the data and the stats for all adapter index/pairs
 					final Query q = QueryBuilder.newBuilder().build();
-					internalQuery(q, true);
-				} catch (Exception e) {
-					LOGGER.error("Unable to delete the requested data", e);
+					internalQuery(
+							q,
+							true);
+				}
+				catch (Exception e) {
+					LOGGER.error(
+							"Unable to delete the requested data",
+							e);
 				}
 			}
 			else {
@@ -532,20 +477,18 @@ public class BaseDataStore implements
 										query.getCommonQueryOptions().getAuthorizations());
 							}
 							catch (final IOException e) {
-								LOGGER
-										.warn(
-												"Unable to delete by adapter",
-												e);
+								LOGGER.warn(
+										"Unable to delete by adapter",
+										e);
 								return false;
 							}
 						}
 					}
 				}
 				catch (final IOException e) {
-					LOGGER
-							.warn(
-									"Unable to get adapters to delete",
-									e);
+					LOGGER.warn(
+							"Unable to get adapters to delete",
+							e);
 					return false;
 				}
 			}
@@ -585,10 +528,9 @@ public class BaseDataStore implements
 			return true;
 		}
 		catch (final Exception e) {
-			LOGGER
-					.error(
-							"Unable to delete all tables",
-							e);
+			LOGGER.error(
+					"Unable to delete all tables",
+					e);
 
 		}
 		return false;
@@ -599,21 +541,19 @@ public class BaseDataStore implements
 			final Index index,
 			final String... additionalAuthorizations )
 			throws IOException {
-		
-		//we don't want to delete the stats for the adapter do we?
-		statisticsStore
-				.removeAllStatistics(
-						adapter.getAdapterId(),
-						additionalAuthorizations);
+
+		// we don't want to delete the stats for the adapter do we?
+		statisticsStore.removeAllStatistics(
+				adapter.getAdapterId(),
+				additionalAuthorizations);
 
 		// cannot delete because authorizations are not used
 		// this.indexMappingStore.remove(adapter.getAdapterId());
 
-		baseOperations
-				.deleteAll(
-						index.getName(),
-						adapter.getAdapterId(),
-						additionalAuthorizations);
+		baseOperations.deleteAll(
+				index.getName(),
+				adapter.getAdapterId(),
+				additionalAuthorizations);
 	}
 
 	protected CloseableIterator<Object> queryConstraints(
@@ -625,54 +565,45 @@ public class BaseDataStore implements
 			final PersistentAdapterStore tempAdapterStore,
 			final boolean delete ) {
 		final BaseConstraintsQuery constraintsQuery = new BaseConstraintsQuery(
-				ArrayUtils
-						.toPrimitive(
-								adapterIdsToQuery
-										.toArray(
-												new Short[0])),
+				ArrayUtils.toPrimitive(adapterIdsToQuery.toArray(new Short[0])),
 				index,
 				sanitizedQuery,
 				filter,
 				sanitizedQueryOptions.getScanCallback(),
 				sanitizedQueryOptions.getAggregation(),
 				sanitizedQueryOptions.getFieldIdsAdapterPair(),
-				IndexMetaDataSet
-						.getIndexMetadata(
-								index,
-								adapterIdsToQuery,
-								statisticsStore,
-								sanitizedQueryOptions.getAuthorizations()),
-				DuplicateEntryCount
-						.getDuplicateCounts(
-								index,
-								adapterIdsToQuery,
-								statisticsStore,
-								sanitizedQueryOptions.getAuthorizations()),
-				DifferingFieldVisibilityEntryCount
-						.getVisibilityCounts(
-								index,
-								adapterIdsToQuery,
-								statisticsStore,
-								sanitizedQueryOptions.getAuthorizations()),
-				FieldVisibilityCount
-						.getVisibilityCounts(
-								index,
-								adapterIdsToQuery,
-								statisticsStore,
-								sanitizedQueryOptions.getAuthorizations()),
+				IndexMetaDataSet.getIndexMetadata(
+						index,
+						adapterIdsToQuery,
+						statisticsStore,
+						sanitizedQueryOptions.getAuthorizations()),
+				DuplicateEntryCount.getDuplicateCounts(
+						index,
+						adapterIdsToQuery,
+						statisticsStore,
+						sanitizedQueryOptions.getAuthorizations()),
+				DifferingFieldVisibilityEntryCount.getVisibilityCounts(
+						index,
+						adapterIdsToQuery,
+						statisticsStore,
+						sanitizedQueryOptions.getAuthorizations()),
+				FieldVisibilityCount.getVisibilityCounts(
+						index,
+						adapterIdsToQuery,
+						statisticsStore,
+						sanitizedQueryOptions.getAuthorizations()),
 				sanitizedQueryOptions.getAuthorizations());
 
-		return constraintsQuery
-				.query(
-						baseOperations,
-						baseOptions,
-						tempAdapterStore,
-						internalAdapterStore,
-						sanitizedQueryOptions.getMaxResolutionSubsamplingPerDimension(),
-						sanitizedQueryOptions.getTargetResolutionPerDimensionForHierarchicalIndex(),
-						sanitizedQueryOptions.getLimit(),
-						sanitizedQueryOptions.getMaxRangeDecomposition(),
-						delete);
+		return constraintsQuery.query(
+				baseOperations,
+				baseOptions,
+				tempAdapterStore,
+				internalAdapterStore,
+				sanitizedQueryOptions.getMaxResolutionSubsamplingPerDimension(),
+				sanitizedQueryOptions.getTargetResolutionPerDimensionForHierarchicalIndex(),
+				sanitizedQueryOptions.getLimit(),
+				sanitizedQueryOptions.getMaxRangeDecomposition(),
+				delete);
 	}
 
 	protected CloseableIterator<Object> queryRowPrefix(
@@ -733,19 +664,14 @@ public class BaseDataStore implements
 		final DifferingFieldVisibilityEntryCount differingVisibilityCounts = DifferingFieldVisibilityEntryCount
 				.getVisibilityCounts(
 						index,
-						Collections
-								.singletonList(
-										adapter.getAdapterId()),
+						Collections.singletonList(adapter.getAdapterId()),
 						statisticsStore,
 						sanitizedQueryOptions.getAuthorizations());
-		final FieldVisibilityCount visibilityCounts = FieldVisibilityCount
-				.getVisibilityCounts(
-						index,
-						Collections
-								.singletonList(
-										adapter.getAdapterId()),
-						statisticsStore,
-						sanitizedQueryOptions.getAuthorizations());
+		final FieldVisibilityCount visibilityCounts = FieldVisibilityCount.getVisibilityCounts(
+				index,
+				Collections.singletonList(adapter.getAdapterId()),
+				statisticsStore,
+				sanitizedQueryOptions.getAuthorizations());
 		final BaseInsertionIdQuery<Object> q = new BaseInsertionIdQuery<>(
 				adapter,
 				index,
@@ -755,17 +681,16 @@ public class BaseDataStore implements
 				differingVisibilityCounts,
 				visibilityCounts,
 				sanitizedQueryOptions.getAuthorizations());
-		return q
-				.query(
-						baseOperations,
-						baseOptions,
-						tempAdapterStore,
-						internalAdapterStore,
-						sanitizedQueryOptions.getMaxResolutionSubsamplingPerDimension(),
-						sanitizedQueryOptions.getTargetResolutionPerDimensionForHierarchicalIndex(),
-						sanitizedQueryOptions.getLimit(),
-						sanitizedQueryOptions.getMaxRangeDecomposition(),
-						delete);
+		return q.query(
+				baseOperations,
+				baseOptions,
+				tempAdapterStore,
+				internalAdapterStore,
+				sanitizedQueryOptions.getMaxResolutionSubsamplingPerDimension(),
+				sanitizedQueryOptions.getTargetResolutionPerDimensionForHierarchicalIndex(),
+				sanitizedQueryOptions.getLimit(),
+				sanitizedQueryOptions.getMaxRangeDecomposition(),
+				delete);
 	}
 
 	protected <T> Writer<T> createIndexWriter(
@@ -879,28 +804,19 @@ public class BaseDataStore implements
 
 	@Override
 	public Index[] getIndices() {
-		return getIndices(
-				null);
+		return getIndices(null);
 	}
 
 	@Override
 	public Index[] getIndices(
 			final String typeName ) {
-		final Short internalAdapterId = internalAdapterStore
-				.getAdapterId(
-						typeName);
+		final Short internalAdapterId = internalAdapterStore.getAdapterId(typeName);
 		if (internalAdapterId == null) {
-			LOGGER
-					.warn(
-							"Unable to find adapter '" + typeName + "' for indices");
+			LOGGER.warn("Unable to find adapter '" + typeName + "' for indices");
 			return new Index[0];
 		}
-		final AdapterToIndexMapping indices = indexMappingStore
-				.getIndicesForAdapter(
-						internalAdapterId);
-		return indices
-				.getIndices(
-						indexStore);
+		final AdapterToIndexMapping indices = indexMappingStore.getIndicesForAdapter(internalAdapterId);
+		return indices.getIndices(indexStore);
 	}
 
 	@Override
@@ -1029,11 +945,8 @@ public class BaseDataStore implements
 		// add internal adapter
 		final InternalDataAdapter<T> internalAdapter = new InternalDataAdapterWrapper<>(
 				dataTypeAdapter,
-				internalAdapterStore
-						.addTypeName(
-								dataTypeAdapter.getTypeName()));
-		store(
-				internalAdapter);
+				internalAdapterStore.addTypeName(dataTypeAdapter.getTypeName()));
+		store(internalAdapter);
 	}
 
 	/**
@@ -1044,41 +957,26 @@ public class BaseDataStore implements
 	@Override
 	public <T> Writer<T> createWriter(
 			final String typeName ) {
-		final Short adapterId = internalAdapterStore
-				.getAdapterId(
-						typeName);
+		final Short adapterId = internalAdapterStore.getAdapterId(typeName);
 		if (adapterId == null) {
-			LOGGER
-					.warn(
-							"DataTypeAdapter does not exist for type '" + typeName
-									+ "'. Add it using addType(<dataTypeAdapter>).");
+			LOGGER.warn("DataTypeAdapter does not exist for type '" + typeName
+					+ "'. Add it using addType(<dataTypeAdapter>).");
 			return null;
 		}
-		final InternalDataAdapter<T> adapter = (InternalDataAdapter<T>) adapterStore
-				.getAdapter(
-						adapterId);
+		final InternalDataAdapter<T> adapter = (InternalDataAdapter<T>) adapterStore.getAdapter(adapterId);
 		if (adapter == null) {
-			LOGGER
-					.warn(
-							"DataTypeAdapter is undefined for type '" + typeName
-									+ "'. Add it using addType(<dataTypeAdapter>).");
+			LOGGER.warn("DataTypeAdapter is undefined for type '" + typeName
+					+ "'. Add it using addType(<dataTypeAdapter>).");
 			return null;
 		}
-		final AdapterToIndexMapping mapping = indexMappingStore
-				.getIndicesForAdapter(
-						adapterId);
+		final AdapterToIndexMapping mapping = indexMappingStore.getIndicesForAdapter(adapterId);
 		if (mapping == null) {
-			LOGGER
-					.warn(
-							"No indices for type '" + typeName
-									+ "'. Add indices using addIndex(<typename>, <indices>).");
+			LOGGER.warn("No indices for type '" + typeName + "'. Add indices using addIndex(<typename>, <indices>).");
 			return null;
 		}
 		return createWriter(
 				adapter,
-				mapping
-						.getIndices(
-								indexStore));
+				mapping.getIndices(indexStore));
 	}
 
 	@Override
@@ -1106,9 +1004,7 @@ public class BaseDataStore implements
 	public <P extends Persistable, R, T> R aggregate(
 			final AggregationQuery<P, R, T> query ) {
 		if (query == null) {
-			LOGGER
-					.warn(
-							"Aggregation must be defined");
+			LOGGER.warn("Aggregation must be defined");
 			return null;
 		}
 		return (R) internalQuery(
@@ -1262,106 +1158,137 @@ public class BaseDataStore implements
 			final DataStore other,
 			final Query<?> query ) {
 		if (query == null) {
-			copyTo(
-					other);
+			copyTo(other);
 		}
 		// TODO issue #1440 addresses filling out this method
 	}
 
 	@Override
 	public void removeIndex(
-			String indexName ) throws AdapterException {
+			String indexName )
+			throws AdapterException {
 		// remove the given index for all types
-		CloseableIterator<InternalDataAdapter<? >> it = adapterStore.getAdapters();
-		
-		// this is a little convoluted and requires iterating over all the adapters,
-		// getting each adapter's index map, checking if the index is there, and then mark it for removal
-		// from both the map and from the index store. If this index is the only index remaining
+		CloseableIterator<InternalDataAdapter<?>> it = adapterStore.getAdapters();
+
+		// this is a little convoluted and requires iterating over all the
+		// adapters,
+		// getting each adapter's index map, checking if the index is there, and
+		// then mark it for removal
+		// from both the map and from the index store. If this index is the only
+		// index remaining
 		// for a given type, then we need to throw an exception
 		final ArrayList<Short> markedAdapters = new ArrayList<Short>();
-		while(it.hasNext()) {
-			
-			final InternalDataAdapter<? > dataAdapter = it.next();
-			final AdapterToIndexMapping adapterIndexMap = indexMappingStore.getIndicesForAdapter(dataAdapter.getAdapterId());
+		while (it.hasNext()) {
+
+			final InternalDataAdapter<?> dataAdapter = it.next();
+			final AdapterToIndexMapping adapterIndexMap = indexMappingStore.getIndicesForAdapter(dataAdapter
+					.getAdapterId());
 			final String[] indexNames = adapterIndexMap.getIndexNames();
-			for(int i = 0; i < indexNames.length; i++) {
-				if(indexNames[i].equals(indexName)) {
-					//check if it is the only index for the current adapter
-					if(indexNames.length == 1) {
-						throw new AdapterException("Index removal failed. Adapters require at least one index.");
-					} else {
-						//mark the index for removal
+			for (int i = 0; i < indexNames.length; i++) {
+				if (indexNames[i].equals(indexName)) {
+					// check if it is the only index for the current adapter
+					if (indexNames.length == 1) {
+						throw new AdapterException(
+								"Index removal failed. Adapters require at least one index.");
+					}
+					else {
+						// mark the index for removal
 						markedAdapters.add(dataAdapter.getAdapterId());
 					}
 				}
 			}
 		}
 		it.close();
-		
+
 		// take out the index from the mapping, statistics, and data
-		for(int i = 0; i < markedAdapters.size(); i++) {
+		for (int i = 0; i < markedAdapters.size(); i++) {
 			short adapterId = markedAdapters.get(i);
-			
+
 			// delete the data and the stats for this adapter/index combination
-			final Query q = QueryBuilder.newBuilder().addTypeName(internalAdapterStore.getTypeName(adapterId)).indexName(indexName).build();
-			internalQuery(q, true);
-			indexMappingStore.remove(adapterId, indexName);
+			final Query q = QueryBuilder.newBuilder().addTypeName(
+					internalAdapterStore.getTypeName(adapterId)).indexName(
+					indexName).build();
+			internalQuery(
+					q,
+					true);
+			indexMappingStore.remove(
+					adapterId,
+					indexName);
 		}
-		//remove the actual index
-		indexStore.remove(indexName);	
+		// remove the actual index
+		indexStore.remove(indexName);
 	}
 
 	@Override
-	public void removeIndex(
+	public void removeIndexMapping(
 			String typeName,
-			String indexName ) throws AdapterException {		
+			String indexName )
+			throws AdapterException, IllegalArgumentException {
 		short adapterId = internalAdapterStore.getAdapterId(typeName);
-		
+
 		final AdapterToIndexMapping adapterIndexMap = indexMappingStore.getIndicesForAdapter(adapterId);
+		if(adapterIndexMap == null) {
+			throw new IllegalArgumentException("No adapter with typeName " + typeName + "could be found.");
+		}
+		
 		final String[] indexNames = adapterIndexMap.getIndexNames();
-		if(indexNames.length == 1) {
-			throw new AdapterException("Index removal failed. Adapters require at least one index.");
-		} else {
+		if (indexNames.length == 1) {
+			throw new AdapterException(
+					"Index mapping removal failed. Adapters require at least one index.");
+		}
+		else {
 			// delete the data and the stats for this adapter/index combination
-			final Query q = QueryBuilder.newBuilder().addTypeName(typeName).indexName(indexName).build();
-			internalQuery(q, true);
-			
-			//clean up the index/adapter mapping
-			indexMappingStore.remove(adapterId, indexName);	
+			final Query q = QueryBuilder.newBuilder().addTypeName(
+					typeName).indexName(
+					indexName).build();
+			internalQuery(
+					q,
+					true);
+
+			// clean up the index/adapter mapping
+			indexMappingStore.remove(
+					adapterId,
+					indexName);
 		}
 	}
 
 	@Override
 	public void removeType(
 			String typeName ) {
-		// Removing a type requires removing the data associated with the type, the index mapping
+		// Removing a type requires removing the data associated with the type,
+		// the index mapping
 		// for the type, we also need to remove stats for the type.
 		final Short adapterId = internalAdapterStore.getAdapterId(typeName);
-		
-		if(adapterId != -1) {
+
+		if (adapterId != -1) {
 			final AdapterToIndexMapping mapping = indexMappingStore.getIndicesForAdapter(adapterId);
 			final String[] indexNames = mapping.getIndexNames();
-			
-			//remove all the data for each index paired to this adapter
-			for(int i = 0; i < indexNames.length; i++) {
-				baseOperations.deleteAll(indexNames[i], adapterId);
+
+			// remove all the data for each index paired to this adapter
+			for (int i = 0; i < indexNames.length; i++) {
+				baseOperations.deleteAll(
+						indexNames[i],
+						adapterId);
 			}
-			
+
 			statisticsStore.removeAllStatistics(adapterId);
 			indexMappingStore.remove(adapterId);
 			internalAdapterStore.remove(adapterId);
 			adapterStore.removeAdapter(adapterId);
-		}		
+		}
 	}
 
 	@Override
 	public void deleteAll() {
-		//delete all the data for every adapter and every index
+		// delete all the data for every adapter and every index
 		try {
-			//passing null deletes everything!
+			// passing null deletes everything!
 			delete(null);
-		} catch (Exception e) {
-			LOGGER.error("Unable to delete the requested data", e);
+		}
+		catch (Exception e) {
+			LOGGER.error(
+					"Unable to delete the requested data",
+					e);
 		}
 	}
 }

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/base/BaseDataStore.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/base/BaseDataStore.java
@@ -1177,7 +1177,7 @@ public class BaseDataStore implements
 		// If this index is the only index remaining for a given type, then we need 
 		// to throw an exception first (no deletion will occur).
 	
-		final ArrayList<AdapterToIndexMapping> markedAdapters = new ArrayList<AdapterToIndexMapping>();
+		final ArrayList<Short> markedAdapters = new ArrayList<Short>();
 		while (it.hasNext()) {
 
 			final InternalDataAdapter<?> dataAdapter = it.next();
@@ -1193,7 +1193,7 @@ public class BaseDataStore implements
 					}
 					else {
 						// mark the index for removal
-						markedAdapters.add(adapterIndexMap);
+						markedAdapters.add(adapterIndexMap.getAdapterId());
 					}
 				}
 			}
@@ -1202,15 +1202,11 @@ public class BaseDataStore implements
 
 		// take out the index from the mapping, statistics, and data
 		for (int i = 0; i < markedAdapters.size(); i++) {
-			final AdapterToIndexMapping adapterMap = markedAdapters.get(i);
-			final short adapterId = adapterMap.getAdapterId();
+			final short adapterId = markedAdapters.get(i);
 
-			// maintain consistency and remove the adapter data from all the indices
-			// (equivalent to deleting all the data for the adapter)
-			for (String mappedIndexName : adapterMap.getIndexNames()) {
-				baseOperations.deleteAll(mappedIndexName, adapterId);
-			}
-			
+			//remove the data
+			baseOperations.deleteAll(indexName, adapterId);
+						
 			// remove all stats for the adapter
 			this.statisticsStore.removeAllStatistics(adapterId);
 						

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/index/IndexStore.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/index/IndexStore.java
@@ -26,7 +26,8 @@ public interface IndexStore
 
 	public CloseableIterator<Index> getIndices();
 
-	public void remove(String indexName);
-	
+	public void removeIndex(
+			String indexName );
+
 	public void removeAll();
 }

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/index/IndexStore.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/index/IndexStore.java
@@ -26,5 +26,7 @@ public interface IndexStore
 
 	public CloseableIterator<Index> getIndices();
 
+	public void remove(String indexName);
+	
 	public void removeAll();
 }

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/metadata/AbstractGeoWavePersistence.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/metadata/AbstractGeoWavePersistence.java
@@ -97,15 +97,6 @@ public abstract class AbstractGeoWavePersistence<T extends Persistable>
 		cache.invalidateAll();
 	}
 
-	public void remove(
-			String indexName ) {
-		// TODO check on this logic
-		//deleteObject(
-		//		new ByteArrayId(indexName),
-		//		null);
-		cache.invalidateAll();
-	}
-
 	protected ByteArrayId getCombinedId(
 			final ByteArrayId primaryId,
 			final ByteArrayId secondaryId ) {

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/metadata/AbstractGeoWavePersistence.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/metadata/AbstractGeoWavePersistence.java
@@ -149,9 +149,9 @@ public abstract class AbstractGeoWavePersistence<T extends Persistable>
 	}
 
 	public void remove(
-			final ByteArrayId adapterId ) {
+			final ByteArrayId primaryId ) {
 		deleteObject(
-				adapterId,
+				primaryId,
 				null);
 
 	}

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/metadata/AbstractGeoWavePersistence.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/metadata/AbstractGeoWavePersistence.java
@@ -97,6 +97,15 @@ public abstract class AbstractGeoWavePersistence<T extends Persistable>
 		cache.invalidateAll();
 	}
 
+	public void remove(
+			String indexName ) {
+		// TODO check on this logic
+		//deleteObject(
+		//		new ByteArrayId(indexName),
+		//		null);
+		cache.invalidateAll();
+	}
+
 	protected ByteArrayId getCombinedId(
 			final ByteArrayId primaryId,
 			final ByteArrayId secondaryId ) {
@@ -399,7 +408,8 @@ public abstract class AbstractGeoWavePersistence<T extends Persistable>
 		}
 		try (final MetadataDeleter deleter = operations.createMetadataDeleter(type)) {
 			if (primaryId != null) {
-				//TODO look at issue #1443, this should delete multiple - also in general does this delete from the cache???
+				// TODO look at issue #1443, this should delete multiple - also
+				// in general does this delete from the cache???
 				return deleter.delete(new MetadataQuery(
 						primaryId.getBytes(),
 						secondaryId != null ? secondaryId.getBytes() : null,

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/metadata/IndexStoreImpl.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/metadata/IndexStoreImpl.java
@@ -52,27 +52,36 @@ public class IndexStoreImpl extends
 	public Index getIndex(
 			final String indexName ) {
 		return getObject(
-				new ByteArrayId(indexName),
+				new ByteArrayId(
+						indexName),
 				null);
 	}
 
 	@Override
 	protected ByteArrayId getPrimaryId(
 			final Index persistedObject ) {
-		return new ByteArrayId(persistedObject.getName());
+		return new ByteArrayId(
+				persistedObject.getName());
 	}
 
 	@Override
 	public boolean indexExists(
 			final String indexName ) {
 		return objectExists(
-				new ByteArrayId(indexName),
+				new ByteArrayId(
+						indexName),
 				null);
 	}
 
 	@Override
 	public CloseableIterator<Index> getIndices() {
 		return getObjects();
+	}
+	
+	@Override
+	public void removeIndex(
+			String indexName ) {
+		remove(new ByteArrayId(indexName));
 	}
 
 }


### PR DESCRIPTION
Currently the two `removeIndex` methods behave slightly differently. The one that also accepts a typename in the parameters simply removes the adapter/index mapping but does not actually delete the index. The other removes the mapping and deletes the index for all adapters. This may need to be clarified with better naming i.e. `removeIndexMapping`. `AdapterException` is used to throw an error anytime the user tries to remove the last index for an adapter, perhaps there is a better one?